### PR TITLE
feat: Allow import of applications to state

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -46,3 +46,15 @@ output "example_app" {
 
 - `id` (String) The ID of this resource.
 - `last_updated` (String)
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Applications can be imported using the sonatype application id.
+# This can be obtained by searching using the PublicID in the WebUI or by calling the rest API
+
+# Example
+terraform import 4bb67dcfc86344e3a483832f8c496419
+```

--- a/examples/resources/sonatypeiq_application/import.sh
+++ b/examples/resources/sonatypeiq_application/import.sh
@@ -1,0 +1,5 @@
+# Applications can be imported using the sonatype application id.
+# This can be obtained by searching using the PublicID in the WebUI or by calling the rest API
+
+# Example
+terraform import 4bb67dcfc86344e3a483832f8c496419

--- a/internal/provider/application_resource.go
+++ b/internal/provider/application_resource.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"io"
 	"time"
 
@@ -27,6 +28,8 @@ import (
 
 	sonatypeiq "github.com/sonatype-nexus-community/nexus-iq-api-client-go"
 )
+
+var _ resource.ResourceWithImportState = &applicationResource{}
 
 // applicationResource is the resource implementation.
 type applicationResource struct {
@@ -161,6 +164,9 @@ func (r *applicationResource) Read(ctx context.Context, req resource.ReadRequest
 		state.Name = types.StringValue(*application.Name)
 		state.PublicId = types.StringValue(*application.PublicId)
 		state.OrganizationId = types.StringValue(*application.OrganizationId)
+		if state.LastUpdated == types.StringValue("") {
+			state.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
+		}
 		if application.ContactUserName != nil {
 			state.ContactUserName = types.StringValue(*application.ContactUserName)
 		} else {
@@ -247,4 +253,8 @@ func (r *applicationResource) Delete(ctx context.Context, req resource.DeleteReq
 		)
 		return
 	}
+}
+
+func (r *applicationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/application_resource_test.go
+++ b/internal/provider/application_resource_test.go
@@ -28,6 +28,7 @@ func TestAccApplicationResource(t *testing.T) {
 
 	appName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
+	resourceName := "sonatypeiq_application.test"
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -36,20 +37,32 @@ func TestAccApplicationResource(t *testing.T) {
 				Config: testAccApplicationResource(appName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Application
-					resource.TestCheckResourceAttrSet("sonatypeiq_application.test", "id"),
-					resource.TestCheckResourceAttr("sonatypeiq_application.test", "name", appName),
-					resource.TestCheckResourceAttr("sonatypeiq_application.test", "public_id", appName),
-					resource.TestCheckResourceAttrSet("sonatypeiq_application.test", "last_updated"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", appName),
+					resource.TestCheckResourceAttr(resourceName, "public_id", appName),
+					resource.TestCheckResourceAttrSet(resourceName, "last_updated"),
 				),
 			},
 			{
 				Config: testAccApplicationResource(appName, "2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("sonatypeiq_application.test", "id"),
-					resource.TestCheckResourceAttr("sonatypeiq_application.test", "name", appName+"2"),
-					resource.TestCheckResourceAttr("sonatypeiq_application.test", "public_id", appName+"2"),
-					resource.TestCheckResourceAttrSet("sonatypeiq_application.test", "last_updated"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", appName+"2"),
+					resource.TestCheckResourceAttr(resourceName, "public_id", appName+"2"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_updated"),
 				),
+			},
+			// Validate
+			{
+				Config:             testAccApplicationResource(appName, "2"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_updated"},
 			},
 			// Delete testing automatically occurs in TestCase
 		},


### PR DESCRIPTION
This is an attempt to implement the import of applications created outside of Terraform control raised in #21 

I am a little confused about the purpose of the `last_updated` attribute as I can't find any reference to this in the rest API, to allow the import to work I have added to the Read function that this is set if it is not already in the state. The acceptance tests have been extended to check that a plan after create doesn't update that attribute.

The way the imports are tested the existing resource is imported to a new state file and the 2 states are compared, as the new import has a different last_updated this is ignored.