### PR TITLE
fix: When the organization ID is changed the application should be moved

### DIFF
--- a/internal/provider/application_resource.go
+++ b/internal/provider/application_resource.go
@@ -203,6 +203,16 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 		sonatypeiq.ContextBasicAuth,
 		r.auth,
 	)
+	if !plan.OrganizationId.Equal(state.OrganizationId) {
+		_, apiResponse, err := r.client.ApplicationsAPI.MoveApplication(ctx, state.ID.ValueString(), plan.OrganizationId.ValueString()).Execute()
+		if err != nil {
+			errorBody, _ := io.ReadAll(apiResponse.Body)
+			resp.Diagnostics.AddError(
+				"Error moving application", "Could not move the application("+state.ID.ValueString()+") to new organization("+plan.OrganizationId.String()+"): "+apiResponse.Status+": "+string(errorBody),
+			)
+			return
+		}
+	}
 	app_update_request := r.client.ApplicationsAPI.UpdateApplication(ctx, state.ID.ValueString())
 	app_update_request = app_update_request.ApiApplicationDTO(sonatypeiq.ApiApplicationDTO{
 		Name:            plan.Name.ValueStringPointer(),


### PR DESCRIPTION
I have been unable to run the new tests as is as I don't have access to the root org in our installation. I did test by using 2 orgs I do have access to so quite confident the proposed solution is OK. I wanted to avoid having to setup an org just for this test, happy to update to using that approach if the root org can't be used for some reason.

I have also added a prefix to created resources in tests, if the test fails and a resource is left dangling it makes it easier to identify.

closes: #25 