### PR TITLE
fix: Add RequiresReplace for organizationRoleMembershipResource to allow changes

### DIFF
--- a/examples/resources/sonatypeiq_organization_role_membership/resource.tf
+++ b/examples/resources/sonatypeiq_organization_role_membership/resource.tf
@@ -18,9 +18,8 @@ resource "sonatypeiq_user" "example" {
 resource "sonatypeiq_organization_role_membership" "organization_role_membership" {
   organization_id = data.sonatypeiq_organization.sandbox.id
   role_id         = data.sonatypeiq_role.developer.id
-  username        = sonatypeiq_user.example.username
+  user_name       = sonatypeiq_user.example.username
 
   # group_name can also be used but it is mutually exclusive with the user_name attribute.
   # group_name = "developers"
 }
-

--- a/internal/provider/organization_role_membership_resource.go
+++ b/internal/provider/organization_role_membership_resource.go
@@ -26,6 +26,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	sonatypeiq "github.com/sonatype-nexus-community/nexus-iq-api-client-go"
@@ -64,18 +66,30 @@ func (r *organizationRoleMembershipResource) Schema(_ context.Context, _ resourc
 			"role_id": schema.StringAttribute{
 				Required:    true,
 				Description: "The role ID",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"organization_id": schema.StringAttribute{
 				Required:    true,
 				Description: "The organization ID",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"user_name": schema.StringAttribute{
 				Optional:    true,
 				Description: "The username of the user (mutually exclusive with group_name)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"group_name": schema.StringAttribute{
 				Optional:    true,
 				Description: "The group name of the group (mutually exclusive with user_name)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/organization_role_membership_resource_test.go
+++ b/internal/provider/organization_role_membership_resource_test.go
@@ -34,33 +34,63 @@ func TestAccOrganizationRoleMembershipResource(t *testing.T) {
 			// Create and Read testing
 			{
 				Config: fmt.Sprintf(providerConfig+`
-        data "sonatypeiq_organization" "sandbox" {
-          name = "Sandbox Organization"
-        }
-
-        data "sonatypeiq_role" "developer" {
-          name = "Developer"
-        }
-
-        resource "sonatypeiq_user" "user" {
-          username   = "%s"
-          password   = "randomthing"
-          first_name = "Example"
-          last_name  = "User"
-          email      = "example@user.tld"
-        }
-
-        resource "sonatypeiq_organization_role_membership" "test" {
-          role_id         = data.sonatypeiq_role.developer.id
-          organization_id = data.sonatypeiq_organization.sandbox.id
-          user_name       = sonatypeiq_user.user.username
-        }
-
-        `, userName),
+		 data "sonatypeiq_organization" "sandbox" {
+		   name = "Sandbox Organization"
+		 }
+ 
+		 data "sonatypeiq_role" "developer" {
+		   name = "Developer"
+		 }
+ 
+		 resource "sonatypeiq_user" "user" {
+		   username   = "%s"
+		   password   = "randomthing"
+		   first_name = "Example"
+		   last_name  = "User"
+		   email      = "example@user.tld"
+		 }
+ 
+		 resource "sonatypeiq_organization_role_membership" "test" {
+		   role_id         = data.sonatypeiq_role.developer.id
+		   organization_id = data.sonatypeiq_organization.sandbox.id
+		   user_name       = sonatypeiq_user.user.username
+		 }
+ 
+		 `, userName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify application role membership
 					resource.TestCheckResourceAttrSet("sonatypeiq_organization_role_membership.test", "id"),
 					resource.TestCheckResourceAttr("sonatypeiq_organization_role_membership.test", "user_name", userName),
+				),
+			},
+			{
+				Config: fmt.Sprintf(providerConfig+`
+		 data "sonatypeiq_organization" "sandbox" {
+		   name = "Sandbox Organization"
+		 }
+ 
+		 data "sonatypeiq_role" "owner" {
+		   name = "Owner"
+		 }
+ 
+		 resource "sonatypeiq_user" "user" {
+		   username   = "%s"
+		   password   = "randomthing"
+		   first_name = "Example"
+		   last_name  = "User"
+		   email      = "example@user.tld"
+		 }
+ 
+		 resource "sonatypeiq_organization_role_membership" "test" {
+		   role_id         = data.sonatypeiq_role.owner.id
+		   organization_id = data.sonatypeiq_organization.sandbox.id
+		   user_name       = sonatypeiq_user.user.username
+		 }
+ 
+		 `, userName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify application role membership
+					resource.TestCheckResourceAttr("sonatypeiq_organization_role_membership.test", "role_id", "1cddabf7fdaa47d6833454af10e0a3ef"),
 				),
 			},
 		},


### PR DESCRIPTION
Developed together with @iverberk 

When changing/updating something in an existing sonatypeiq_organization_role_membership resource, the provider crashed stating panic unimplemented. With this change, a change to an existing sonatypeiq_organization_role_membership resource forces a replace of that resource, hereby allowing the change/update.